### PR TITLE
Made empty enum return a label of UNKNOWN when calling getLabel()

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -229,6 +229,10 @@ abstract class Enum
      */
     public static function label($typeValue): string
     {
+        if ($typeValue === '') {
+            $typeValue = null;
+        }
+
         $langId = 'typelabels.' . get_called_class() . '.' . strtolower((string) self::search($typeValue));
 
         if (Lang::has($langId)) {

--- a/tests/Unit/EnumFixture.php
+++ b/tests/Unit/EnumFixture.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace LenderSpender\LaravelEnums\Tests\Unit;
 
 use LenderSpender\LaravelEnums\Enum;

--- a/tests/Unit/EnumTest.php
+++ b/tests/Unit/EnumTest.php
@@ -305,6 +305,7 @@ class EnumTest extends TestCase
         };
 
         self::assertSame('', $nullableEnum->value());
+        self::assertSame('UNKNOWN', $nullableEnum->getLabel());
         self::assertTrue($nullableEnum::UNKNOWN()->equals($nullableEnum));
     }
 


### PR DESCRIPTION
getLabel of an empty Enum would return a boolean (since it would default to the `search` function). The getLabel should return a string not a boolean.

[Linked to this issue](https://lenderspender.atlassian.net/jira/software/projects/LSP/boards/4?assignee=5f27122e2aa2500028ab54d5&selectedIssue=LSP-631)